### PR TITLE
Fix overwriting RediStore options in Delete() with Go 1.1

### DIFF
--- a/redistore.go
+++ b/redistore.go
@@ -114,9 +114,9 @@ func (s *RediStore) Delete(r *http.Request, w http.ResponseWriter, session *sess
 		return err
 	}
 	// Set cookie to expire.
-	options := session.Options
+	options := *session.Options
 	options.MaxAge = -1
-	http.SetCookie(w, sessions.NewCookie(session.Name(), "", options))
+	http.SetCookie(w, sessions.NewCookie(session.Name(), "", &options))
 	// Clear session values.
 	for k := range session.Values {
 		delete(session.Values, k)


### PR DESCRIPTION
After deleting a session all subsequently created session cookies have  Expires and MaxAge set to wrong values:

 Expires=Thu, 01 Jan 1970 00:00:01 UTC; Max-Age=0

Reason for this seems to that the Go 1.1 compiler optimises out the intended copy in line 78 (session.Options = &(*s.Options)) which makes line 118 (options.MaxAge = -1) overwrite the original RediStore options instead of the private session copy.
