### PR TITLE
Enable injection of the underlying *redis.Pool

### DIFF
--- a/redistore.go
+++ b/redistore.go
@@ -106,9 +106,9 @@ func NewRediStoreWithDB(size int, network, address, password, DB string, keyPair
 	return rs
 }
 
-// Close cleans up the redis connections.
-func (s *RediStore) Close() {
-	s.Pool.Close()
+// Close closes the underlying *redis.Pool
+func (s *RediStore) Close() error {
+	return s.Pool.Close()
 }
 
 // Get returns a session for the given name after adding it to the registry.


### PR DESCRIPTION
This change set adds a new constructor which enables dependency injection of the underlying *redis.Pool which is necessary in scenarios where you're managing many pools on a global level and want to reuse them.
The rest of the changes is meant to reuse the new code which also make it automatically tested.
