### PR TITLE
Generate session.ID in New instead of Save

### DIFF
--- a/redistore.go
+++ b/redistore.go
@@ -133,8 +133,13 @@ func (s *RediStore) New(r *http.Request, name string) (*sessions.Session, error)
 			session.IsNew = !(err == nil && ok) // not new if no error and data available
 		}
 	}
+	if session.ID == "" {
+		session.ID = strings.TrimRight(base32.StdEncoding.EncodeToString(securecookie.GenerateRandomKey(32)), "=")
+	}
 	return session, err
 }
+
+var ErrEmptySessionID = errors.New("Empty session id")
 
 // Save adds a single session to the response.
 func (s *RediStore) Save(r *http.Request, w http.ResponseWriter, session *sessions.Session) error {
@@ -144,20 +149,23 @@ func (s *RediStore) Save(r *http.Request, w http.ResponseWriter, session *sessio
 			return err
 		}
 		http.SetCookie(w, sessions.NewCookie(session.Name(), "", session.Options))
-	} else {
-		// Build an alphanumeric key for the redis store.
-		if session.ID == "" {
-			session.ID = strings.TrimRight(base32.StdEncoding.EncodeToString(securecookie.GenerateRandomKey(32)), "=")
-		}
-		if err := s.save(session); err != nil {
-			return err
-		}
-		encoded, err := securecookie.EncodeMulti(session.Name(), session.ID, s.Codecs...)
-		if err != nil {
-			return err
-		}
-		http.SetCookie(w, sessions.NewCookie(session.Name(), encoded, session.Options))
+		return nil
 	}
+
+	if session.ID == "" {
+		return ErrEmptySessionID
+	}
+
+	if err := s.save(session); err != nil {
+		return err
+	}
+
+	encoded, err := securecookie.EncodeMulti(session.Name(), session.ID, s.Codecs...)
+	if err != nil {
+		return err
+	}
+	http.SetCookie(w, sessions.NewCookie(session.Name(), encoded, session.Options))
+
 	return nil
 }
 

--- a/redistore_test.go
+++ b/redistore_test.go
@@ -308,6 +308,25 @@ func TestRediStore(t *testing.T) {
 	}
 }
 
+func TestSessionSave(t *testing.T) {
+	store := NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
+	req, err := http.NewRequest("GET", "http://www.example.com", nil)
+	if err != nil {
+		t.Fatal("failed to create request", err)
+	}
+	w := httptest.NewRecorder()
+
+	session, err := store.New(req, "my session")
+	if err != nil || session.ID == "" {
+		t.Fatal("Unexpected condition on store.New: %s", err)
+	}
+
+	session.ID = ""
+	if err = session.Save(req, w); err != ErrEmptySessionID {
+		t.Fatal("Unexpected error on session.Save. Want: %s, Got: %s", ErrEmptySessionID, err)
+	}
+}
+
 func ExampleRediStore() {
 	// RedisStore
 	store := NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))


### PR DESCRIPTION
In environments where redis is sharded across multiple machines and the
shard key is the session.ID, it is necessary to know this key before
picking the server / pool to which the write is going.
