### PR TITLE
Added a way to configure storage MaxAge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ See http://www.gorillatoolkit.org/pkg/sessions for full documentation on underly
         t.Fatalf("Error saving session: %v", err)
     }
 
+    // Change session storage configuration for MaxAge = 10 days.
+    store.SetMaxAge(10*34*3600)
+
+
 ## Notes
 
 #### July 18th, 2013

--- a/redistore_test.go
+++ b/redistore_test.go
@@ -258,7 +258,7 @@ func TestRediStore(t *testing.T) {
 		t.Fatal("expected an error, got nil")
 	}
 
-	store.MaxLength(4096 * 3) // A bit more than the value size to account for encoding overhead.
+	store.SetMaxLength(4096 * 3) // A bit more than the value size to account for encoding overhead.
 	err = session.Save(req, w)
 	if err != nil {
 		t.Fatal("failed to Save:", err)


### PR DESCRIPTION
Current implementation suffers for inconsistent way of handling `MaxAge`.
On one side we have `RediStore.Options.MaxAge` as a `session.Options` used by redis TTL and browser MaxAge/Expire.  
On the other side we use `securecookie.SecureCookie` as a default codec. It has it's own maxAge config, which is not connected to the one from `RediStore.Options`. 
When the former one is bigger then the letter one we encounter a nasty issue, where the cookie is active both in a browser and storage, but `SecureCookie` fails to decode it because of timestamp restriction related to `SecureCookie.maxAge`.

In this pull request I've added two commits:
- extract a common part of `NewRediStore*` funcitons
- handle an issue with MaxAge described above (more info in commit message).

Also I'm opt to hide `RediStore.Options` (to change it to `RediStore.options`). Of course session object will expose it, but at least we could have a consistent way to set storage configuration in a _checked_ way.
