### PR TITLE
RediStore.New() should make a clone of Options.

### DIFF
--- a/redistore.go
+++ b/redistore.go
@@ -149,7 +149,9 @@ func (s *RediStore) Get(r *http.Request, name string) (*sessions.Session, error)
 func (s *RediStore) New(r *http.Request, name string) (*sessions.Session, error) {
 	var err error
 	session := sessions.NewSession(s, name)
-	session.Options = s.Options
+	// make a copy
+	options := *s.Options
+	session.Options = &options
 	session.IsNew = true
 	if c, errCookie := r.Cookie(name); errCookie == nil {
 		err = securecookie.DecodeMulti(name, c.Value, &session.ID, s.Codecs...)


### PR DESCRIPTION
Fix a bug where setting fields such as session.MaxAge affects the value for all sessions constructed via New().

Found this when my logout logic caused all sessions to be invalidated.
