### PR TITLE
Add SessionSerializer interface

### DIFF
--- a/redistore.go
+++ b/redistore.go
@@ -61,11 +61,11 @@ func (s JSONSerializer) Deserialize(d []byte, ss *sessions.Session) error {
 	return nil
 }
 
-// GOBSerializer uses gob package to encode the session map
-type GOBSerializer struct{}
+// GobSerializer uses gob package to encode the session map
+type GobSerializer struct{}
 
 // Serialize using gob
-func (s GOBSerializer) Serialize(ss *sessions.Session) ([]byte, error) {
+func (s GobSerializer) Serialize(ss *sessions.Session) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	enc := gob.NewEncoder(buf)
 	err := enc.Encode(ss.Values)
@@ -76,7 +76,7 @@ func (s GOBSerializer) Serialize(ss *sessions.Session) ([]byte, error) {
 }
 
 // Deserialize back to map[interface{}]interface{}
-func (s GOBSerializer) Deserialize(d []byte, ss *sessions.Session) error {
+func (s GobSerializer) Deserialize(d []byte, ss *sessions.Session) error {
 	dec := gob.NewDecoder(bytes.NewBuffer(d))
 	return dec.Decode(&ss.Values)
 }
@@ -214,7 +214,7 @@ func NewRediStoreWithPool(pool *redis.Pool, keyPairs ...[]byte) (*RediStore, err
 		DefaultMaxAge: 60 * 20, // 20 minutes seems like a reasonable default
 		maxLength:     4096,
 		keyPrefix:     "session_",
-		serializer:    GOBSerializer{},
+		serializer:    GobSerializer{},
 	}
 	_, err := rs.ping()
 	return rs, err

--- a/redistore_test.go
+++ b/redistore_test.go
@@ -89,7 +89,7 @@ func TestRediStore(t *testing.T) {
 	// Round 1 ----------------------------------------------------------------
 
 	// RedisStore
-	store, err := NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
+	store, err := NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -166,7 +166,7 @@ func TestRediStore(t *testing.T) {
 	// Custom type
 
 	// RedisStore
-	store, err = NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
+	store, err = NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -251,7 +251,7 @@ func TestRediStore(t *testing.T) {
 	// Round 6 ----------------------------------------------------------------
 	// RediStore change MaxLength of session
 
-	store, err = NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
+	store, err = NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -277,7 +277,7 @@ func TestRediStore(t *testing.T) {
 	// Round 7 ----------------------------------------------------------------
 
 	// RedisStoreWithDB
-	store, err = NewRediStoreWithDB(10, "tcp", ":6378", "", "1", []byte("secret-key"))
+	store, err = NewRediStoreWithDB(10, "tcp", ":6379", "", "1", []byte("secret-key"))
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -324,7 +324,7 @@ func TestRediStore(t *testing.T) {
 	// JSONSerializer
 
 	// RedisStore
-	store, err = NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
+	store, err = NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
 	store.SetSerializer(JSONSerializer{})
 	if err != nil {
 		t.Fatal(err.Error())
@@ -370,7 +370,7 @@ func TestRediStore(t *testing.T) {
 }
 
 func TestPingGoodPort(t *testing.T) {
-	store, _ := NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
+	store, _ := NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
 	defer store.Close()
 	ok, err := store.ping()
 	if err != nil {
@@ -382,7 +382,7 @@ func TestPingGoodPort(t *testing.T) {
 }
 
 func TestPingBadPort(t *testing.T) {
-	store, _ := NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
+	store, _ := NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
 	defer store.Close()
 	_, err := store.ping()
 	if err == nil {
@@ -392,7 +392,7 @@ func TestPingBadPort(t *testing.T) {
 
 func ExampleRediStore() {
 	// RedisStore
-	store, err := NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
+	store, err := NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
 	if err != nil {
 		panic(err)
 	}

--- a/redistore_test.go
+++ b/redistore_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/gob"
-	"github.com/gorilla/sessions"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/gorilla/sessions"
 )
 
 // ----------------------------------------------------------------------------
@@ -88,7 +89,7 @@ func TestRediStore(t *testing.T) {
 	// Round 1 ----------------------------------------------------------------
 
 	// RedisStore
-	store, err := NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
+	store, err := NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -165,7 +166,7 @@ func TestRediStore(t *testing.T) {
 	// Custom type
 
 	// RedisStore
-	store, err = NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
+	store, err = NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -250,7 +251,7 @@ func TestRediStore(t *testing.T) {
 	// Round 6 ----------------------------------------------------------------
 	// RediStore change MaxLength of session
 
-	store, err = NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
+	store, err = NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -276,7 +277,7 @@ func TestRediStore(t *testing.T) {
 	// Round 7 ----------------------------------------------------------------
 
 	// RedisStoreWithDB
-	store, err = NewRediStoreWithDB(10, "tcp", ":6379", "", "1", []byte("secret-key"))
+	store, err = NewRediStoreWithDB(10, "tcp", ":6378", "", "1", []byte("secret-key"))
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -318,10 +319,58 @@ func TestRediStore(t *testing.T) {
 	if flashes[0] != "foo" {
 		t.Errorf("Expected foo,bar; Got %v", flashes)
 	}
+
+	// Round 8 ----------------------------------------------------------------
+	// JSONSerializer
+
+	// RedisStore
+	store, err = NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
+	store.SetSerializer(JSONSerializer{})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer store.Close()
+
+	req, _ = http.NewRequest("GET", "http://localhost:8080/", nil)
+	rsp = NewRecorder()
+	// Get a session.
+	if session, err = store.Get(req, "session-key"); err != nil {
+		t.Fatalf("Error getting session: %v", err)
+	}
+	// Get a flash.
+	flashes = session.Flashes()
+	if len(flashes) != 0 {
+		t.Errorf("Expected empty flashes; Got %v", flashes)
+	}
+	// Add some flashes.
+	session.AddFlash("foo")
+	// Save.
+	if err = sessions.Save(req, rsp); err != nil {
+		t.Fatalf("Error saving session: %v", err)
+	}
+	hdr = rsp.Header()
+	cookies, ok = hdr["Set-Cookie"]
+	if !ok || len(cookies) != 1 {
+		t.Fatalf("No cookies. Header:", hdr)
+	}
+
+	// Get a session.
+	req.Header.Add("Cookie", cookies[0])
+	if session, err = store.Get(req, "session-key"); err != nil {
+		t.Fatalf("Error getting session: %v", err)
+	}
+	// Check all saved values.
+	flashes = session.Flashes()
+	if len(flashes) != 1 {
+		t.Fatalf("Expected flashes; Got %v", flashes)
+	}
+	if flashes[0] != "foo" {
+		t.Errorf("Expected foo,bar; Got %v", flashes)
+	}
 }
 
 func TestPingGoodPort(t *testing.T) {
-	store, _ := NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
+	store, _ := NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
 	defer store.Close()
 	ok, err := store.ping()
 	if err != nil {
@@ -343,7 +392,7 @@ func TestPingBadPort(t *testing.T) {
 
 func ExampleRediStore() {
 	// RedisStore
-	store, err := NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
+	store, err := NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This adds a SessionSerializer interface which provides a hook to specify the encoder used to de/serialize session data. There are two built-ins: GobSerializer which provides the same functionality as the current implementation and JSONSerializer which serialises to JSON.