### PR TITLE
Use new Redigo repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A session store backend for [gorilla/sessions](http://www.gorillatoolkit.org/pkg
 
 ## Requirements
 
-Depends on the [Redigo](https://github.com/garyburd/redigo) Redis library.
+Depends on the [Redigo](https://github.com/gomodule/redigo) Redis library.
 
 ## Installation
 

--- a/redistore.go
+++ b/redistore.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
 )

--- a/redistore.go
+++ b/redistore.go
@@ -252,7 +252,7 @@ func (s *RediStore) New(r *http.Request, name string) (*sessions.Session, error)
 // Save adds a single session to the response.
 func (s *RediStore) Save(r *http.Request, w http.ResponseWriter, session *sessions.Session) error {
 	// Marked for deletion.
-	if session.Options.MaxAge < 0 {
+	if session.Options.MaxAge <= 0 {
 		if err := s.delete(session); err != nil {
 			return err
 		}


### PR DESCRIPTION
The original redigo repo (github.com/garyburd/redigo) has been archived. It is now being actively supported at github.com/gomodule/redigo. I updated all references to garyburd/redigo to use gomodule/redigo instead.