### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/boj/redistore
+
+require (
+	github.com/gomodule/redigo v2.0.0
+	github.com/gorilla/sessions v1.1.1
+)


### PR DESCRIPTION
Addresses #43. Branches from #42 - so merge after.

Need to resolve internal package issue - 
```
➜ penguin ~/go/src/github.com/boj/redistore (elithrar/use-travis) ✔  vgo build
vgo: creating new go.mod: module github.com/boj/redistore
vgo: resolving import "github.com/gomodule/redigo/redis"
vgo: finding github.com/gomodule/redigo (latest)
vgo: adding github.com/gomodule/redigo v1.6.0
vgo: resolving import "github.com/gorilla/securecookie"
vgo: finding github.com/gorilla/securecookie (latest)
vgo: adding github.com/gorilla/securecookie v1.1.1
vgo: resolving import "github.com/gorilla/sessions"
vgo: finding github.com/gorilla/sessions (latest)
vgo: adding github.com/gorilla/sessions v1.1.1
vgo: finding github.com/gorilla/sessions v1.1.1
vgo: finding github.com/gorilla/context v1.1.1
vgo: finding github.com/gorilla/securecookie v1.1.1
vgo: finding github.com/gomodule/redigo v1.6.0
vgo: downloading github.com/gomodule/redigo v1.6.0
vgo: downloading github.com/gorilla/securecookie v1.1.1
vgo: downloading github.com/gorilla/sessions v1.1.1
vgo: downloading github.com/gorilla/context v1.1.1
vgo: resolving import "github.com/garyburd/redigo/internal"
vgo: finding github.com/garyburd/redigo (latest)
vgo: adding github.com/garyburd/redigo v1.6.0
vgo: finding github.com/garyburd/redigo v1.6.0
vgo: downloading github.com/garyburd/redigo v1.6.0
../../../v/github.com/gomodule/redigo@v1.6.0/redis/pool.go:28:2: use of internal package not allowed
```

(Last line)