### PR TITLE
fix compatibility with new go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/boj/redistore
 
 require (
-	github.com/gomodule/redigo v2.0.0
+	github.com/gomodule/redigo v2.0.1-0.20180627144507-2cd21d9966bf+incompatible
+	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/gomodule/redigo v2.0.1-0.20180627144507-2cd21d9966bf+incompatible h1:QJ4V3LjaRe/6NKoaaj2QzQZcezt5gNXdPv0axxS4VNA=
+github.com/gomodule/redigo v2.0.1-0.20180627144507-2cd21d9966bf+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
+github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.1.1 h1:YMDmfaK68mUixINzY/XjscuJ47uXFWSSHzFbBQM0PrE=
+github.com/gorilla/sessions v1.1.1/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=


### PR DESCRIPTION
Hey,

I had issues using redistore with go1.11rc1 because the go.mod is out of date and needs a "+incompatible" on the redigo library.
