### PR TITLE
update go.mod to fix go mod error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/boj/redistore
 
 require (
-	github.com/gomodule/redigo v2.0.0
+	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.1.1
 )


### PR DESCRIPTION
fix go module error
```
go: github.com/boj/redistore@v0.0.0-20180706183828-82b86d293eb2: parsing go.mod: go.mod:4: invalid module: github.com/gomodule/redigo should be v0 or v1, not v2 (v2.0.0)
go: error loading module requirements
```