### PR TITLE
Allow maxAge 0 and make defaultMaxAge a variable to create a non-persistent cookie

### DIFF
--- a/redistore.go
+++ b/redistore.go
@@ -24,7 +24,7 @@ import (
 var sessionExpire = 86400 * 30
 
 // Default value of redis ttl when session's maxage is set to zero
-var defaultMaxAge = 60 * 20
+var defaultMaxAge = 86400
 
 // Set defaultMaxAge from outside
 func ChangeDefaultMaxAge(maxAge int) {


### PR DESCRIPTION
Related to the following PR.
https://github.com/boj/redistore/pull/55

Here is the outline of changes.

- Allow `maxAge` 0 when saving a redis store.
- Make `defaultMaxAge` a variable and allow to change this value from outside.

Why allow MaxAge to be 0?

When setting cookie, by not setting a MaxAge, we can make a one-time cookie and user loses authentication state after closing the browser. And then, user will open website again, the login state would not be persisted and we can prompt to login again.

But if redis TTL is set to zero, server loses the authentication information while user is staying in the browser, and the user's login status will be disappeared

I think it's not uncommon to use redis with some TTL and to set the session's  MaxAge to 0, which is required for my product indeed.

There is already a `defaultMaxAge` property, but now `maxAge` is not allowed to be 0, so `defaultMaxAge` has no chance to be used.

But this approach is flexible, allowing maxAge to be 0, we can set different expiration for session and redis.

Once I'd like to give arguments to `Save` function, but this is an implementation of Interface, so we can't change function structure.

So I accomplish this by changing defaultMaxAge from outside. With this approach we can realize this use case without breaking the implementation of interface.