### PR TITLE
Don't delete session when MaxAge == 0

### DIFF
--- a/redistore.go
+++ b/redistore.go
@@ -252,7 +252,7 @@ func (s *RediStore) New(r *http.Request, name string) (*sessions.Session, error)
 // Save adds a single session to the response.
 func (s *RediStore) Save(r *http.Request, w http.ResponseWriter, session *sessions.Session) error {
 	// Marked for deletion.
-	if session.Options.MaxAge <= 0 {
+	if session.Options.MaxAge < 0 {
 		if err := s.delete(session); err != nil {
 			return err
 		}


### PR DESCRIPTION
MaxAge == 0 means the cookie should exist within browser's session, the cookie will be deleted once browser closed(If the MaxAge >0 cookie will be stored until expiration even the browser is closed). And server ttl could be manually set by RediStore.DefaultMaxAge.

