### PR TITLE
refactor: refactor RediStore to support username parameter

### DIFF
--- a/redistore.go
+++ b/redistore.go
@@ -209,7 +209,7 @@ func (s *RediStore) SetMaxAge(v int) {
 // NewRediStore creates a new RediStore with a connection pool to a Redis server.
 // The size parameter specifies the maximum number of idle connections in the pool.
 // The network and address parameters specify the network type and address of the Redis server.
-// The password parameter is used for authentication with the Redis server.
+// The username and password parameters are used for authentication with the Redis server.
 // The keyPairs parameter is a variadic argument that allows passing multiple key pairs for cookie encryption.
 // It returns a pointer to a RediStore and an error if the connection to the Redis server fails.
 func NewRediStore(size int, network, address, username, password string, keyPairs ...[]byte) (*RediStore, error) {
@@ -248,20 +248,21 @@ func dialClient(network, address, username, password, DB string) (redis.Conn, er
 }
 
 // NewRediStoreWithDB creates a new RediStore with a Redis connection pool.
-// The pool is configured with the given size, network, address, password, and database (DB).
-// The keyPairs are used for cookie encryption and decryption.
+// The pool is configured with the provided size, network, address, username, password, and database (DB).
+// The keyPairs are used for cookie encryption.
 //
 // Parameters:
-// - size: The maximum number of idle connections in the pool.
-// - network: The network type (e.g., "tcp").
-// - address: The address of the Redis server (e.g., "localhost:6379").
-// - password: The password for the Redis server.
-// - DB: The database to select after connecting to the Redis server.
-// - keyPairs: Variadic parameter for encryption and decryption keys.
+//   - size: The maximum number of idle connections in the pool.
+//   - network: The network type (e.g., "tcp").
+//   - address: The address of the Redis server.
+//   - username: The username for Redis authentication.
+//   - password: The password for Redis authentication.
+//   - DB: The Redis database to be selected after connecting.
+//   - keyPairs: Variadic parameter for cookie encryption keys.
 //
 // Returns:
-// - *RediStore: A pointer to the created RediStore.
-// - error: An error if the store could not be created.
+//   - *RediStore: A pointer to the newly created RediStore.
+//   - error: An error if the RediStore could not be created.
 func NewRediStoreWithDB(size int, network, address, username, password, DB string, keyPairs ...[]byte) (*RediStore, error) {
 	return NewRediStoreWithPool(&redis.Pool{
 		MaxIdle:     size,

--- a/redistore_test.go
+++ b/redistore_test.go
@@ -98,7 +98,7 @@ func TestRediStore(t *testing.T) {
 	var ok bool
 	t.Run("Round 1", func(t *testing.T) {
 		addr := setup()
-		store, err := NewRediStore(10, "tcp", addr, "", []byte("secret-key"))
+		store, err := NewRediStore(10, "tcp", addr, "", "", []byte("secret-key"))
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -129,7 +129,7 @@ func TestRediStore(t *testing.T) {
 
 	t.Run("Round 2", func(t *testing.T) {
 		addr := setup()
-		store, err := NewRediStore(10, "tcp", addr, "", []byte("secret-key"))
+		store, err := NewRediStore(10, "tcp", addr, "", "", []byte("secret-key"))
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -171,7 +171,7 @@ func TestRediStore(t *testing.T) {
 
 	t.Run("Round 3", func(t *testing.T) {
 		addr := setup()
-		store, err := NewRediStore(10, "tcp", addr, "", []byte("secret-key"))
+		store, err := NewRediStore(10, "tcp", addr, "", "", []byte("secret-key"))
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -200,7 +200,7 @@ func TestRediStore(t *testing.T) {
 
 	t.Run("Round 4", func(t *testing.T) {
 		addr := setup()
-		store, err := NewRediStore(10, "tcp", addr, "", []byte("secret-key"))
+		store, err := NewRediStore(10, "tcp", addr, "", "", []byte("secret-key"))
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -229,7 +229,7 @@ func TestRediStore(t *testing.T) {
 
 	t.Run("Round 6", func(t *testing.T) {
 		addr := setup()
-		store, err := NewRediStore(10, "tcp", addr, "", []byte("secret-key"))
+		store, err := NewRediStore(10, "tcp", addr, "", "", []byte("secret-key"))
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -258,7 +258,7 @@ func TestRediStore(t *testing.T) {
 
 	t.Run("Round 7", func(t *testing.T) {
 		addr := setup()
-		store, err := NewRediStoreWithDB(10, "tcp", addr, "", "1", []byte("secret-key"))
+		store, err := NewRediStoreWithDB(10, "tcp", addr, "", "", "1", []byte("secret-key"))
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -300,7 +300,7 @@ func TestRediStore(t *testing.T) {
 
 	t.Run("Round 8", func(t *testing.T) {
 		addr := setup()
-		store, err := NewRediStore(10, "tcp", addr, "", []byte("secret-key"))
+		store, err := NewRediStore(10, "tcp", addr, "", "", []byte("secret-key"))
 		store.SetSerializer(JSONSerializer{})
 		if err != nil {
 			t.Fatal(err.Error())
@@ -343,7 +343,7 @@ func TestRediStore(t *testing.T) {
 }
 
 func TestPingGoodPort(t *testing.T) {
-	store, _ := NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
+	store, _ := NewRediStore(10, "tcp", ":6379", "", "", []byte("secret-key"))
 	defer store.Close()
 	ok, err := store.ping()
 	if err != nil {
@@ -355,7 +355,7 @@ func TestPingGoodPort(t *testing.T) {
 }
 
 func TestPingBadPort(t *testing.T) {
-	store, _ := NewRediStore(10, "tcp", ":6378", "", []byte("secret-key"))
+	store, _ := NewRediStore(10, "tcp", ":6378", "", "", []byte("secret-key"))
 	defer store.Close()
 	_, err := store.ping()
 	if err == nil {
@@ -402,7 +402,7 @@ func TestNewRediStoreWithURL(t *testing.T) {
 
 func ExampleRediStore() {
 	// RedisStore
-	store, err := NewRediStore(10, "tcp", ":6379", "", []byte("secret-key"))
+	store, err := NewRediStore(10, "tcp", ":6379", "", "", []byte("secret-key"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- Add import for `strconv`
- Remove the `dial` function and its associated comments
- Update `NewRediStore` to include `username` parameter
- Replace `dial` with `dialClient` in `NewRediStore`
- Remove `dialWithDB` function
- Add `dialClient` function with username and database handling
- Update `NewRediStoreWithDB` to include `username` parameter
- Replace `dialWithDB` with `dialClient` in `NewRediStoreWithDB`
- Update tests to include `username` parameter in `NewRediStore` and `NewRediStoreWithDB` calls

fix https://github.com/boj/redistore/pull/65