### PR TITLE
Fix: Avoid password authentication for Redis when no password is set …

### DIFF
--- a/redistore.go
+++ b/redistore.go
@@ -237,6 +237,17 @@ func dialClient(network, address, username, password, DB string) (redis.Conn, er
 	if err != nil {
 		return nil, err
 	}
+	
+	// If there is no password, the redis. DialPassword
+	if password == "" {
+		// Only the database index is passed.
+		return redis.Dial(
+			network,
+			address,
+			redis.DialUsername(username),
+			redis.DialDatabase(db),
+		)
+	}
 
 	return redis.Dial(
 		network,


### PR DESCRIPTION
The current implementation attempts to authenticate with Redis even when no password is set. If Redis does not require authentication, this results in an unnecessary authentication attempt with an empty password, causing a connection failure. This fix ensures that if no password is provided, the connection attempt will skip the password authentication step, allowing successful connections to Redis instances without password authentication.