### PR TITLE
feat: add support for TLS connections

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: "fs"
           scan-ref: "."

--- a/README.md
+++ b/README.md
@@ -278,6 +278,36 @@ func main() {
 | `WithAddress(network, address)` | Connect via network and address (e.g., "tcp", ":6379")   |
 | `WithURL(url)`                  | Connect via Redis URL (e.g., "redis://localhost:6379/0") |
 
+### TLS / Secure Connections
+
+If your Redis instance requires TLS, use `WithAddress` together with `WithTLS` to enable TLS.
+- `WithTLS(enable bool, disableTLSVerification bool, tlsConfig *tls.Config)` — enable TLS when connecting via `WithAddress`.
+    - Set `enable` to `true` to enable TLS for address-based connections.
+    - Pass `true` to `disableTLSVerification` to skip certificate verification (use only for testing).
+    - Or pass a non-nil `*tls.Config` to configure TLS parameters (preferred for production).
+    - `disableTLSVerification` and `tlsConfig` are mutually exclusive.
+
+Example (skip verification - testing only):
+
+```go
+store, err := redistore.NewStore(
+    redistore.KeysFromStrings("secret-key"),
+    redistore.WithAddress("tcp", "redis.example.com:6380"),
+    redistore.WithTLS(true, true, nil),
+)
+```
+
+Example (custom TLS config):
+
+```go
+tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
+store, err := redistore.NewStore(
+    redistore.KeysFromStrings("secret-key"),
+    redistore.WithAddress("tcp", "redis.example.com:6380"),
+    redistore.WithTLS(true, false, tlsCfg),
+)
+```
+
 ### Authentication Options
 
 | Option                         | Description               |

--- a/redistore_tls_integration_test.go
+++ b/redistore_tls_integration_test.go
@@ -1,0 +1,92 @@
+package redistore
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// TestRedisTLSIntegration is an optional integration test that requires a
+// TLS-enabled Redis instance. It is skipped unless the environment variable
+// TLS_REDIS_ADDR is set (for example: "localhost:6380").
+//
+// Optional environment variables:
+// - TLS_REDIS_ADDR: host:port of TLS-enabled Redis (required to run)
+// - TLS_SKIP_VERIFY: set to "1" to skip server cert verification (testing only)
+// - TLS_REDIS_CA: path to PEM file containing CA(s) to trust for the server cert
+//
+// NOTE:
+// The current github action used for Redis does not support TLS.
+// This one does but it does not support password authentication.
+// https://github.com/marketplace/actions/actions-setup-redis
+//
+//	So there is a script that can be run locally to run the Redis TLS integration test.
+//	See scripts/run-redis-tls-and-test.sh
+func TestRedisTLSIntegration(t *testing.T) {
+	addr := os.Getenv("TLS_REDIS_ADDR")
+	if addr == "" {
+		t.Skip("TLS integration test skipped; set TLS_REDIS_ADDR to run")
+	}
+
+	caPath := os.Getenv("TLS_REDIS_CA")
+	skipVerify := os.Getenv("TLS_SKIP_VERIFY") == "1"
+
+	var tlsCfg *tls.Config
+	if caPath != "" {
+		// #nosec g703
+		data, err := os.ReadFile(caPath)
+		if err != nil {
+			t.Fatalf("failed to read CA file: %v", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(data) {
+			t.Fatalf("failed to parse CA file: %s", caPath)
+		}
+		tlsCfg = &tls.Config{RootCAs: pool}
+	}
+
+	opts := []Option{
+		WithAddress("tcp", addr),
+		WithPoolSize(5),
+	}
+	if tlsCfg != nil {
+		opts = append(opts, WithTLS(true, false, tlsCfg))
+	} else if skipVerify {
+		opts = append(opts, WithTLS(true, true, nil))
+	} else {
+		// default to skip-verify when no CA is provided
+		opts = append(opts, WithTLS(true, true, nil))
+	}
+
+	store, err := NewStore(
+		[][]byte{[]byte("integration-key")},
+		opts...,
+	)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	defer store.Close()
+
+	ok, err := store.ping()
+	if err != nil {
+		t.Fatalf("ping failed: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected PONG from Redis")
+	}
+
+	// Also exercise Save to ensure TLS-backed SETEX works
+	req, _ := http.NewRequest("GET", "https://example.local/", nil)
+	rr := httptest.NewRecorder()
+	sess, err := store.New(req, "tls-integration")
+	if err != nil {
+		t.Fatalf("store.New failed: %v", err)
+	}
+	sess.Values["k"] = "v"
+	if err := store.Save(req, rr, sess); err != nil {
+		t.Fatalf("store.Save failed: %v", err)
+	}
+}

--- a/scripts/run-redis-tls-and-test.sh
+++ b/scripts/run-redis-tls-and-test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run a TLS-enabled Redis in Docker, run the TLS integration test, then cleanup.
+# Usage:
+#   ./scripts/run-redis-tls-and-test.sh        # create artifacts, run test, cleanup
+#   KEEP=1 ./scripts/run-redis-tls-and-test.sh # keep container and files for inspection
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKDIR="$HERE/redis-tls-test"
+mkdir -p "$WORKDIR/certs"
+cd "$WORKDIR"
+
+echo "Working dir: $WORKDIR"
+
+if [ ! -f certs/ca.crt ]; then
+  echo "Generating CA and server certificates..."
+  openssl genrsa -out certs/ca.key 4096
+  openssl req -x509 -new -nodes -key certs/ca.key -sha256 -days 3650 -subj "/CN=Redis Test CA" -out certs/ca.crt
+
+  openssl genrsa -out certs/redis.key 4096
+  openssl req -new -key certs/redis.key -subj "/CN=redis.local" -out certs/redis.csr
+  printf "subjectAltName = IP:127.0.0.1, DNS:redis.local\n" > certs/redis.ext
+  openssl x509 -req -in certs/redis.csr -CA certs/ca.crt -CAkey certs/ca.key -CAcreateserial -out certs/redis.crt -days 365 -sha256 -extfile certs/redis.ext
+fi
+
+# Ensure correct permissions: private key must be owner-readable only so Redis can load it
+chmod 644 certs/redis.key || true
+chmod 644 certs/redis.crt certs/ca.crt || true
+
+cat > redis.conf <<'EOF'
+tls-port 6379
+port 0
+bind 0.0.0.0
+tls-cert-file /certs/redis.crt
+tls-key-file  /certs/redis.key
+tls-ca-cert-file /certs/ca.crt
+tls-auth-clients no
+protected-mode no
+EOF
+
+echo "Removing any existing container named redis-tls..."
+if docker ps -a --format '{{.Names}}' | grep -q '^redis-tls$'; then
+  docker rm -f redis-tls >/dev/null || true
+fi
+
+echo "Starting redis:7 container with TLS enabled (host port 6380 -> container 6379)..."
+docker run -d --name redis-tls -p 6380:6379 -v "$PWD/redis.conf":/usr/local/etc/redis/redis.conf:ro -v "$PWD/certs":/certs:ro redis:7 redis-server /usr/local/etc/redis/redis.conf
+
+echo "Waiting for TLS Redis to respond to PING..."
+for i in {1..30}; do
+  echo "Waiting for TLS Redis to respond to PING...attempt $i/30"
+  if docker run --rm -v "$PWD/certs":/certs --link redis-tls:redis redis:7 redis-cli --tls -h redis -p 6379 --cacert /certs/ca.crt PING 2>/dev/null | grep -q PONG; then
+    echo "Redis TLS is up"
+    break
+  fi
+  sleep 1
+done
+
+echo "Running Go TLS integration test..."
+export TLS_REDIS_ADDR=127.0.0.1:6380
+export TLS_REDIS_CA="$PWD/certs/ca.crt"
+(
+  cd "$HERE"
+  TLS_REDIS_ADDR=$TLS_REDIS_ADDR TLS_REDIS_CA=$TLS_REDIS_CA go test -run TestRedisTLSIntegration -v
+)
+TEST_EXIT=$?
+
+if [ "${KEEP:-}" = "1" ]; then
+  echo "KEEP=1; leaving container and artifacts in $WORKDIR"
+  exit $TEST_EXIT
+fi
+
+echo "Cleaning up..."
+docker rm -f redis-tls >/dev/null || true
+rm -rf "$WORKDIR"
+
+exit $TEST_EXIT


### PR DESCRIPTION
Added support for enabling TLS connections to Redis. This allows users of this package to enhance security.

The current github action used for Redis does not support TLS. This [one](https://github.com/marketplace/actions/actions-setup-redis) does, however, it does not support password authentication. So there is a script that can be run locally to run the Redis TLS integration test `scripts/run-redis-tls-and-test.sh`. I am not really familiar with github actions -  I am happy to change this if there is a better way of doing this.