### PR TITLE
fix(store): merge WithURL fields with WithAuth/WithPassword/WithDB, only error on real conflict

### DIFF
--- a/redistore.go
+++ b/redistore.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -419,6 +420,60 @@ func defaultConfig() *storeConfig {
 	}
 }
 
+// redisURLParts captures the connection components extracted from a Redis
+// URL. Empty fields indicate that the URL did not specify that component,
+// so a later merge step can fall back to WithAuth / WithPassword / WithDB.
+type redisURLParts struct {
+	network  string // "tcp" or "unix"
+	address  string // host:port for tcp, socket path for unix
+	username string // empty if not in URL
+	password string // empty if not in URL
+	db       string // empty if not in URL
+}
+
+// parseRedisURL extracts the connection components from a Redis URL.
+// It supports the redis://, rediss://, and unix:// schemes. An empty
+// field in the returned struct means the URL did not specify that
+// component.
+func parseRedisURL(rawURL string) (*redisURLParts, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	parts := &redisURLParts{}
+
+	switch u.Scheme {
+	case "redis", "rediss":
+		parts.network = "tcp"
+		parts.address = u.Host
+	case "unix":
+		// For unix sockets the entire path is the socket file. The redis
+		// URL format does not specify a database component on top of it.
+		parts.network = "unix"
+		parts.address = u.Path
+		parts.db = ""
+		return parts, nil
+	default:
+		return nil, fmt.Errorf(
+			"unsupported URL scheme %q (expected redis://, rediss://, or unix://)",
+			u.Scheme,
+		)
+	}
+
+	if u.User != nil {
+		parts.username = u.User.Username()
+		if pwd, ok := u.User.Password(); ok {
+			parts.password = pwd
+		}
+	}
+
+	// Path looks like "/0", "/5", or empty; "" means "not specified".
+	parts.db = strings.TrimPrefix(u.Path, "/")
+
+	return parts, nil
+}
+
 // validate checks that the configuration is valid.
 // It ensures that exactly one connection option is specified and all values are sensible.
 func (cfg *storeConfig) validate() error {
@@ -444,6 +499,35 @@ func (cfg *storeConfig) validate() error {
 			"only one connection option can be specified: " +
 				"WithPool, WithAddress, or WithURL are mutually exclusive",
 		)
+	}
+
+	// When using WithURL, the URL may omit username, password, or database.
+	// Those missing fields are filled in by the corresponding WithAuth /
+	// WithPassword / WithDB options. A field is only in conflict — and
+	// therefore an error — when *both* the URL and an option specify it.
+	if cfg.url != "" {
+		parts, err := parseRedisURL(cfg.url)
+		if err != nil {
+			return err
+		}
+		if parts.username != "" && cfg.username != "" {
+			return errors.New(
+				"WithURL already specifies a username; " +
+					"remove WithAuth or remove the userinfo from the URL",
+			)
+		}
+		if parts.password != "" && cfg.password != "" {
+			return errors.New(
+				"WithURL already specifies a password; " +
+					"remove WithPassword (or the password in WithAuth) or remove the password from the URL",
+			)
+		}
+		if parts.db != "" && cfg.db != "0" {
+			return errors.New(
+				"WithURL already specifies a database; " +
+					"remove WithDB or remove the database path from the URL",
+			)
+		}
 	}
 
 	return nil
@@ -473,9 +557,34 @@ func (cfg *storeConfig) buildPool() (*redis.Pool, error) {
 			)
 		}
 	case cfg.url != "":
-		// Use URL-based connection
+		// Use URL-based connection. URL components are merged with any
+		// WithAuth/WithPassword/WithDB options: each field comes from the
+		// URL when present, otherwise from the matching option, otherwise
+		// from the default. The validator has already rejected the case
+		// where both sides specify the same field.
+		parts, err := parseRedisURL(cfg.url)
+		if err != nil {
+			return nil, fmt.Errorf("invalid URL: %w", err)
+		}
+
+		username := parts.username
+		if username == "" {
+			username = cfg.username
+		}
+		password := parts.password
+		if password == "" {
+			password = cfg.password
+		}
+		db := parts.db
+		if db == "" {
+			db = cfg.db
+		}
+
+		network := parts.network
+		address := parts.address
+
 		dialFunc = func() (redis.Conn, error) {
-			return redis.DialURL(cfg.url)
+			return dialClient(network, address, username, password, db)
 		}
 	default:
 		return nil, errors.New("no connection method specified")

--- a/redistore_options_test.go
+++ b/redistore_options_test.go
@@ -1,6 +1,7 @@
 package redistore
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -45,6 +46,220 @@ func TestNewStore_MultipleConnectionOptions(t *testing.T) {
 		"WithPool, WithAddress, or WithURL are mutually exclusive"
 	if err.Error() != expectedErr {
 		t.Errorf("Unexpected error message: %v", err)
+	}
+}
+
+// expectedURLFieldErrPrefix is the prefix shared by every URL/option
+// per-field conflict error. The validator appends the specific field
+// name, so tests only assert on the prefix to stay decoupled from the
+// exact wording of each message.
+const expectedURLFieldErrPrefix = "invalid configuration: WithURL already specifies a "
+
+// TestParseRedisURL exercises the URL parser used by both validate() and
+// buildPool(). It does not need a running Redis.
+func TestParseRedisURL(t *testing.T) {
+	t.Run("Valid URLs", func(t *testing.T) {
+		cases := []struct {
+			raw      string
+			network  string
+			address  string
+			username string
+			password string
+			db       string
+		}{
+			{"redis://localhost:6379", "tcp", "localhost:6379", "", "", ""},
+			{"redis://localhost:6379/0", "tcp", "localhost:6379", "", "", "0"},
+			{"redis://localhost:6379/5", "tcp", "localhost:6379", "", "", "5"},
+			{"redis://:pw@localhost:6379", "tcp", "localhost:6379", "", "pw", ""},
+			{"redis://user@localhost:6379", "tcp", "localhost:6379", "user", "", ""},
+			{"redis://user:pw@localhost:6379/3", "tcp", "localhost:6379", "user", "pw", "3"},
+			{"rediss://localhost:6379", "tcp", "localhost:6379", "", "", ""},
+			{"unix:///tmp/redis.sock", "unix", "/tmp/redis.sock", "", "", ""},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.raw, func(t *testing.T) {
+				parts, err := parseRedisURL(tc.raw)
+				if err != nil {
+					t.Fatalf("parseRedisURL(%q) returned error: %v", tc.raw, err)
+				}
+				if parts.network != tc.network {
+					t.Errorf("network: want %q, got %q", tc.network, parts.network)
+				}
+				if parts.address != tc.address {
+					t.Errorf("address: want %q, got %q", tc.address, parts.address)
+				}
+				if parts.username != tc.username {
+					t.Errorf("username: want %q, got %q", tc.username, parts.username)
+				}
+				if parts.password != tc.password {
+					t.Errorf("password: want %q, got %q", tc.password, parts.password)
+				}
+				if parts.db != tc.db {
+					t.Errorf("db: want %q, got %q", tc.db, parts.db)
+				}
+			})
+		}
+	})
+
+	t.Run("Invalid scheme", func(t *testing.T) {
+		_, err := parseRedisURL("http://localhost:6379")
+		if err == nil {
+			t.Fatal("Expected error for unsupported scheme")
+		}
+	})
+}
+
+// TestNewStore_URLFieldConflict covers the per-field conflicts that the
+// validator must reject: URL+option both set the username, the password,
+// or a non-default database. For cases that produce two simultaneous
+// conflicts we accept either field name in the error message.
+func TestNewStore_URLFieldConflict(t *testing.T) {
+	cases := []struct {
+		name        string
+		url         string
+		opt         Option
+		mustMention string   // error must mention this fragment
+		orMention   []string // OR one of these (for ambiguous cases)
+	}{
+		{
+			name:        "URL user + WithAuth user",
+			url:         "redis://user@localhost:6379",
+			opt:         WithAuth("user", "pw"),
+			mustMention: "username",
+		},
+		{
+			name:        "URL user:pw + WithAuth user",
+			url:         "redis://user:pw@localhost:6379",
+			opt:         WithAuth("user", "pw"),
+			mustMention: "username",
+		},
+		{
+			name:        "URL password + WithPassword",
+			url:         "redis://:pw@localhost:6379",
+			opt:         WithPassword("pw"),
+			mustMention: "password",
+		},
+		{
+			name:        "URL user:pw + WithPassword",
+			url:         "redis://user:pw@localhost:6379",
+			opt:         WithPassword("pw"),
+			mustMention: "password",
+		},
+		{
+			name:        "URL user:pw + WithAuth mismatched",
+			url:         "redis://user:pw@localhost:6379",
+			opt:         WithAuth("user", "other"),
+			mustMention: "username",
+			orMention:   []string{"password"},
+		},
+		{
+			name:        "URL db /5 + WithDB(\"5\")",
+			url:         "redis://localhost:6379/5",
+			opt:         WithDB("5"),
+			mustMention: "database",
+		},
+		{
+			name:        "URL db /5 + WithDB(\"7\")",
+			url:         "redis://localhost:6379/5",
+			opt:         WithDB("7"),
+			mustMention: "database",
+		},
+		{
+			name:        "URL db /0 + WithDB(\"5\")",
+			url:         "redis://localhost:6379/0",
+			opt:         WithDB("5"),
+			mustMention: "database",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewStore(
+				[][]byte{[]byte("secret-key")},
+				WithURL(tc.url),
+				tc.opt,
+			)
+			if err == nil {
+				t.Fatalf("Expected conflict error, got nil")
+			}
+			msg := err.Error()
+			if !strings.HasPrefix(msg, expectedURLFieldErrPrefix) {
+				t.Errorf("Unexpected error prefix: %v", err)
+			}
+			if !strings.Contains(msg, tc.mustMention) &&
+				!anyContains(msg, tc.orMention) {
+				t.Errorf("Error should mention %q (or one of %v), got: %v",
+					tc.mustMention, tc.orMention, err)
+			}
+		})
+	}
+}
+
+func anyContains(s string, fragments []string) bool {
+	for _, f := range fragments {
+		if strings.Contains(s, f) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestNewStore_URLFieldMerge covers the cases the user can reasonably
+// expect to work: the URL leaves a field empty, and the matching option
+// fills it in. These must NOT trigger a conflict error during validation.
+// We skip the test if no Redis is available (validation will then fail
+// later with a connection error, which is expected and unrelated).
+func TestNewStore_URLFieldMerge(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []Option
+	}{
+		{
+			name: "URL no auth + WithAuth",
+			opts: []Option{WithURL("redis://localhost:6379"), WithAuth("u", "p")},
+		},
+		{
+			name: "URL no auth + WithPassword",
+			opts: []Option{WithURL("redis://localhost:6379"), WithPassword("p")},
+		},
+		{
+			name: "URL no db + WithDB",
+			opts: []Option{WithURL("redis://localhost:6379"), WithDB("5")},
+		},
+		{
+			name: "URL username only + WithPassword",
+			opts: []Option{WithURL("redis://user@localhost:6379"), WithPassword("p")},
+		},
+		{
+			name: "URL password only + WithAuth username only",
+			// WithAuth("u", "") keeps cfg.password empty so the URL's
+			// password does not collide; the option's username fills in.
+			opts: []Option{WithURL("redis://:pw@localhost:6379"), WithAuth("u", "")},
+		},
+		{
+			name: "URL no db /0 + WithDB(\"0\") default",
+			opts: []Option{WithURL("redis://localhost:6379/0"), WithDB("0")},
+		},
+		{
+			name: "URL db /5 + WithDB(\"0\") default",
+			opts: []Option{WithURL("redis://localhost:6379/5"), WithDB("0")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewStore(
+				[][]byte{[]byte("secret-key")},
+				tc.opts...,
+			)
+			// The validation must not have fired. Any error here is a
+			// downstream connection error (no Redis in test env), which
+			// we tolerate.
+			if err != nil && strings.HasPrefix(err.Error(), expectedURLFieldErrPrefix) {
+				t.Fatalf("Validator should have accepted the merge, got: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Background

`WithURL` interacts silently with `WithAuth` / `WithPassword` / `WithDB`: the URL branch of `buildPool` only calls `redis.DialURL(cfg.url)`, so any values set via `WithAuth("u", "p")` or `WithDB("5")` are completely ignored when `WithURL` is also set. There is no error, no warning — the user just silently connects with the URL's credentials (or none) instead of the ones they thought they were configuring. In production this is a footgun for multi-tenant Redis setups and ACL-based auth.

## Changes

Rather than a blanket "URL and options are mutually exclusive" rule, the fix is **per-field conflict detection + field-level merge**:
1. New internal helper [`parseRedisURL`](redistore.go) and struct [`redisURLParts`](redistore.go), supporting the `redis://`, `rediss://`, and `unix://` schemes. For `unix://` the database component is forced to `""` — the socket path is not a db.
2. [`validate()`](redistore.go), when `cfg.url != ""`, checks the `username` / `password` / `db` fields one by one. It only returns an error when *both* the URL and an option set the same field, and the error names the conflicting field.
3. [`buildPool()`](redistore.go) no longer calls `redis.DialURL` for the URL branch. It parses the URL and merges it with `cfg.username` / `cfg.password` / `cfg.db` using "URL first, options fill the gaps", then routes through `dialClient` so every value is actually applied to the dial.